### PR TITLE
serialization / deserialization and error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,50 @@
 # GE-FNM Action Object (@ge-fnm/action-object)
+
 This is the Action Object used within the GE FNM.
 
 [![Coverage Status](https://coveralls.io/repos/github/GE-MDS-FNM-V2/action-object/badge.svg?branch=master)](https://coveralls.io/github/GE-MDS-FNM-V2/action-object?branch=master)
 
-This library is mainly used within the communication-selector-module and the perform-action-module.
+This library is used a common interface between all modules. It contains a standard format for transmitting data, as well as a standard error format.
 
 ## I would like to use the library in my app
+
 To get started with the repository in your project install it like this
+
 ### Install with yarn
+
 ```
 yarn add @ge-fnm/action-object
 ```
+
 ### Install with npm
+
 ```
 npm i @ge-fnm/action-object
 ```
-### Example Usage
+
+### ActionObject Creation and Serialization
+
 Here is an example of how to use it in a browser
 
 ```js
 import { v1, ActionTypeV1, CommunicationMethodV1 } from './action-object'
 
 const obj = v1.create({
-    actionType: ActionTypeV1.GET,
-    commMethod: CommunicationMethodV1.JSONRPC,
-    modifyingValue: 'test',
-    path: ['hello', 'world'],
-    response: undefined,
-    uri: 'http://localhost:5000'
+  version: 1,
+  actionType: ActionTypeV1.GET,
+  commData: {
+    commMethod: CommunicationMethodV1.HTTP,
+    protocol: ProtocolV1.JSONRPC,
+    username: 'john',
+    password: 'adams'
+  },
+  modifyingValue: 'test',
+  path: ['hello', 'world'],
+  response: {
+    data: 'hello world',
+    error: null // note that if error exists, it must be a serialized GEError
+  },
+  uri: 'http://localhost:5000'
 })
 
 const serialized = obj.serialize()
@@ -36,18 +53,42 @@ const objAgain = v1.deserialize(serialized)
 
 // If you would like to initialize an ActionObject with a specific ID, you can do this:
 // NOTE - unless for testing purposes you really shouldn't be doing this
-const obj = v1.create({
-    actionType: ActionTypeV1.GET,
-    commMethod: CommunicationMethodV1.JSONRPC,
-    modifyingValue: 'test',
-    path: ['hello', 'world'],
-    response: undefined,
-    uri: 'http://localhost:5000'
-}, "ThisIsAnOptionalID")
+const obj = v1.create(
+  {
+    ...information
+  },
+  'ThisIsAnOptionalID'
+)
 ```
 
+### GEError creation and serialization
+
+```js
+// for PAM
+import { GEErrors } from '@ge-fnm/action-object'
+const GEPAMError = GEErrors.GEPAMError
+const GEPAMErrorCodes = GEErrors.GEPAMErrorCodes
+throw new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR)
+
+// for CSM
+import { GEErrors } from '@ge-fnm/action-object'
+const GECSMError = GEErrors.GECSMError
+const GECSMErrorCodes = GEErrors.GECSMErrorCodes
+throw new GECSMError('test message', GECSMErrorCodes.NO_FORWARDING_ADDRESS)
+
+// for ActionObject itself - you really shouldnt consume this outside of this repo
+import { GEErrors } from '@ge-fnm/action-object'
+const GEActionObjectError = GEErrors.GEActionObjectError
+const GEActionObjectErrorCodes = GEErrors.GEActionObjectErrorCodes
+throw new GEActionObjectError('test message', GEActionObjectErrorCodes.DESERIALIZATION_ERROR)
+
+```
+
+
 ## Debugging
+
 We've added in optional logging to this module. You can enable it by setting the environment variable DEBUG:
+
 ```sh
 DEBUG=ge-fnm:action-object yarn #to enable logging for only the action-object module
 -or-
@@ -56,5 +97,7 @@ DEBUG=ge-fnm:* yarn # for all logging related to ge-fnm
 DEBUG=* yarn # enable logging for all installed node_modules that look for the env var DEBUG - please note, this is a lot. You probably dont want this
 
 ```
+
 ## I want to work on this project
+
 Please see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is the Action Object used within the GE FNM.
 
 [![Coverage Status](https://coveralls.io/repos/github/GE-MDS-FNM-V2/action-object/badge.svg?branch=master)](https://coveralls.io/github/GE-MDS-FNM-V2/action-object?branch=master)
 
-This library is used a common interface between all modules. It contains a standard format for transmitting data, as well as a standard error format.
+This library is a common interface between all modules. It contains a standard format for transmitting data, as well as a standard error format.
+If _any_ data is going to be transmitted between any module, or any consumer and CSM, use this object.
 
 ## I would like to use the library in my app
 
@@ -24,10 +25,9 @@ npm i @ge-fnm/action-object
 
 ### ActionObject Creation and Serialization
 
-Here is an example of how to use it in a browser
-
+Responding with a simple string
 ```js
-import { v1, ActionTypeV1, CommunicationMethodV1 } from './action-object'
+import { v1, ActionTypeV1, CommunicationMethodV1 } from '@ge-fnm/action-object'
 
 const obj = v1.create({
   version: 1,
@@ -46,6 +46,32 @@ const obj = v1.create({
   },
   uri: 'http://localhost:5000'
 })
+```
+
+Responding with an Error
+```js
+
+import { v1, ActionTypeV1, CommunicationMethodV1, GEErrors } from '@ge-fnm/action-object'
+const GEPAMError = GEErrors.GEPAMError
+const GEPAMErrorCodes = GEErrors.GEPAMErrorCodes
+throw 
+const obj = v1.create({
+  version: 1,
+  actionType: ActionTypeV1.GET,
+  commData: {
+    commMethod: CommunicationMethodV1.HTTP,
+    protocol: ProtocolV1.JSONRPC,
+    username: 'john',
+    password: 'adams'
+  },
+  modifyingValue: 'test',
+  path: ['hello', 'world'],
+  response: {
+    error: new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR) // note that if error exists, it MUST be a serialized GEError
+  },
+  uri: 'http://localhost:5000'
+})
+```
 
 const serialized = obj.serialize()
 const objAgain = v1.deserialize(serialized)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ yarn add @ge-fnm/action-object
 npm i @ge-fnm/action-object
 ```
 
-### ActionObject Creation and Serialization
+### Examples
 
 Responding with a simple string
+
 ```js
 import { v1, ActionTypeV1, CommunicationMethodV1 } from '@ge-fnm/action-object'
 
@@ -42,19 +43,19 @@ const obj = v1.create({
   path: ['hello', 'world'],
   response: {
     data: 'hello world',
-    error: null // note that if error exists, it must be a serialized GEError
+    error: null // note that if error exists, it must be a GEError
   },
   uri: 'http://localhost:5000'
 })
 ```
 
 Responding with an Error
-```js
 
+```js
 import { v1, ActionTypeV1, CommunicationMethodV1, GEErrors } from '@ge-fnm/action-object'
 const GEPAMError = GEErrors.GEPAMError
 const GEPAMErrorCodes = GEErrors.GEPAMErrorCodes
-throw 
+
 const obj = v1.create({
   version: 1,
   actionType: ActionTypeV1.GET,
@@ -67,24 +68,28 @@ const obj = v1.create({
   modifyingValue: 'test',
   path: ['hello', 'world'],
   response: {
-    error: new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR) // note that if error exists, it MUST be a serialized GEError
+    error: new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR) // note that if error exists, it MUST be a GEError
   },
   uri: 'http://localhost:5000'
 })
 ```
 
-const serialized = obj.serialize()
+Serializing / Deserializing
+
+```js
+const obj = v1.create({...})
 const objAgain = v1.deserialize(serialized)
 // objAgain now has all the same properties as obj except with an added 'id' property
 
 // If you would like to initialize an ActionObject with a specific ID, you can do this:
 // NOTE - unless for testing purposes you really shouldn't be doing this
 const obj = v1.create(
-  {
-    ...information
-  },
-  'ThisIsAnOptionalID'
+{
+...information
+},
+'ThisIsAnOptionalID'
 )
+
 ```
 
 ### GEError creation and serialization
@@ -108,8 +113,7 @@ const GEActionObjectError = GEErrors.GEActionObjectError
 const GEActionObjectErrorCodes = GEErrors.GEActionObjectErrorCodes
 throw new GEActionObjectError('test message', GEActionObjectErrorCodes.DESERIALIZATION_ERROR)
 
-```
-
+````
 
 ## Debugging
 

--- a/src/ActionObject.spec.ts
+++ b/src/ActionObject.spec.ts
@@ -41,8 +41,8 @@ describe('v1', () => {
       },
       id
     )
-    expect(obj.serialize()).toEqual(
-      JSON.stringify({
+    expect(obj.serialize()).toEqual({
+      information: {
         version: 1,
         actionType: 'GET',
         commData: {
@@ -57,10 +57,10 @@ describe('v1', () => {
           data: 'hello world',
           error: null
         },
-        uri: 'http://localhost:5000',
-        id: id
-      })
-    )
+        uri: 'http://localhost:5000'
+      },
+      id: id
+    })
   })
   it('Can deserialize valid ActionObject', () => {
     const id = ID()
@@ -136,22 +136,24 @@ describe('v1', () => {
 
   it('Errors if path is not array', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: {},
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      modifyingValue: 'test',
-      path: {},
-      response: {
-        data: 'hello world',
-        error: null
-      },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -161,22 +163,24 @@ describe('v1', () => {
   })
   it('Errors if path is not array of strings', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: ['hello', {}],
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      modifyingValue: 'test',
-      path: ['hello', {}],
-      response: {
-        data: 'hello world',
-        error: null
-      },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -187,18 +191,20 @@ describe('v1', () => {
 
   it('Errors if commData is undefined', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      response: {
-        data: 'hello world',
-        error: null
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -209,21 +215,23 @@ describe('v1', () => {
 
   it('Errors if commData.commMethod is undefined', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      response: {
-        data: 'hello world',
-        error: null
-      },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -234,22 +242,24 @@ describe('v1', () => {
 
   it('Errors if commData.protocol is undefined', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP
-        // protocol: ProtocolV1.JSONRPC,
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP
+          // protocol: ProtocolV1.JSONRPC,
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      response: {
-        data: 'hello world',
-        error: null
-      },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -260,23 +270,25 @@ describe('v1', () => {
 
   it('Errors if commData.username is not a string', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC,
-        username: ['this', 'should', 'fail']
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC,
+          username: ['this', 'should', 'fail']
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      response: {
-        data: 'hello world',
-        error: null
-      },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -286,23 +298,25 @@ describe('v1', () => {
   })
   it('Errors if commData.username is not a string', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC,
-        password: ['this', 'should', 'fail']
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC,
+          password: ['this', 'should', 'fail']
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        response: {
+          data: 'hello world',
+          error: null
+        },
+        uri: 'http://localhost:5000'
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      response: {
-        data: 'hello world',
-        error: null
-      },
-      uri: 'http://localhost:5000',
       id: id
-    })
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -332,19 +346,21 @@ describe('v1', () => {
 
   it('Errors if response is not object', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        uri: 'http://localhost:5000',
+        response: 'asdf'
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      uri: 'http://localhost:5000',
-      id: id,
-      response: 'asdf'
-    })
+      id: id
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -355,19 +371,21 @@ describe('v1', () => {
 
   it('Errors if response doesnt have data and doesnt have error', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        uri: 'http://localhost:5000',
+        response: {}
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      uri: 'http://localhost:5000',
-      id: id,
-      response: {}
-    })
+      id: id
+    }
     try {
       v1.deserialize(obj)
       expect(false).toEqual(true)
@@ -378,41 +396,45 @@ describe('v1', () => {
 
   it('Allows for only response.error', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        uri: 'http://localhost:5000',
+        response: {
+          error: 'adsf'
+        }
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      uri: 'http://localhost:5000',
-      id: id,
-      response: {
-        error: 'adsf'
-      }
-    })
+      id: id
+    }
     v1.deserialize(obj)
   })
 
   it('Allows for only response.data', () => {
     const id = ID()
-    const obj = JSON.stringify({
-      version: 1,
-      actionType: ActionTypeV1.GET,
-      commData: {
-        commMethod: CommunicationMethodV1.HTTP,
-        protocol: ProtocolV1.JSONRPC
+    const obj = {
+      information: {
+        version: 1,
+        actionType: ActionTypeV1.GET,
+        commData: {
+          commMethod: CommunicationMethodV1.HTTP,
+          protocol: ProtocolV1.JSONRPC
+        },
+        modifyingValue: 'test',
+        path: ['hello', 'world'],
+        uri: 'http://localhost:5000',
+        response: {
+          data: 'asdf'
+        }
       },
-      modifyingValue: 'test',
-      path: ['hello', 'world'],
-      uri: 'http://localhost:5000',
-      id: id,
-      response: {
-        data: 'asdf'
-      }
-    })
+      id: id
+    }
     v1.deserialize(obj)
   })
 })

--- a/src/GEError.spec.ts
+++ b/src/GEError.spec.ts
@@ -172,7 +172,7 @@ describe('GEError', () => {
     })
   })
 
-  describe('Serialization', () => {
+  describe('Serialization / Deserialization', () => {
     it('Serializes GEPAMError with properties', () => {
       const err = new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR)
       const serialized = err.toJSON()
@@ -193,6 +193,60 @@ describe('GEError', () => {
       const serialized = err.toJSON()
       const deserialized = GEError.fromJSON(serialized)
       expect(deserialized).toEqual(err)
+    })
+
+    it('Errors if no message prop', () => {
+      try {
+        // @ts-ignore
+        GEError.fromJSON({
+          source: GEErrorEnviornmentSource.CSM,
+          status: GECSMErrorCodes.REMOTE_CSM_CONNECTION_FAILURE,
+          name: 'asdf'
+        })
+        expect(false).toEqual(true)
+      } catch (error) {
+        expect(error).toBeTruthy()
+      }
+    })
+
+    it('Errors if no status prop', () => {
+      try {
+        // @ts-ignore
+        GEError.fromJSON({
+          message: 'asdfasdf',
+          source: GEErrorEnviornmentSource.CSM,
+          name: 'asdf'
+        })
+        expect(false).toEqual(true)
+      } catch (error) {
+        expect(error).toBeTruthy()
+      }
+    })
+    it('Errors if no name prop', () => {
+      try {
+        // @ts-ignore
+        GEError.fromJSON({
+          message: 'asdfasdf',
+          status: GECSMErrorCodes.REMOTE_CSM_CONNECTION_FAILURE,
+          source: GEErrorEnviornmentSource.CSM
+        })
+        expect(false).toEqual(true)
+      } catch (error) {
+        expect(error).toBeTruthy()
+      }
+    })
+    it('Errors if no source prop', () => {
+      try {
+        // @ts-ignore
+        GEError.fromJSON({
+          message: 'asdfasdf',
+          status: GECSMErrorCodes.REMOTE_CSM_CONNECTION_FAILURE,
+          name: GEErrorEnviornmentSource.CSM
+        })
+        expect(false).toEqual(true)
+      } catch (error) {
+        expect(error).toBeTruthy()
+      }
     })
   })
 })

--- a/src/GEError.spec.ts
+++ b/src/GEError.spec.ts
@@ -1,4 +1,5 @@
 import { GEErrors } from './index'
+import { GEActionObjectError, GEActionObjectErrorCodes } from './GEError'
 const GEError = GEErrors.GEError
 const GEPAMError = GEErrors.GEPAMError
 const GEPAMErrorCodes = GEErrors.GEPAMErrorCodes
@@ -100,6 +101,77 @@ describe('GEError', () => {
     })
   })
 
+  describe('GEActionObjectError', () => {
+    it('Should create GEActionObjectError', () => {
+      const test = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      expect(test).toBeTruthy()
+    })
+    it('Should create GEActionObjectError with correct code', () => {
+      const error = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      expect(error.status).toEqual(GEActionObjectErrorCodes.DESERIALIZATION_ERROR)
+    })
+    it('Should create GEActionObjectError with correct message', () => {
+      const error = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      expect(error.message).toEqual('test message')
+    })
+    it('Should create GEActionObjectError with correct name', () => {
+      const error = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      expect(error.name).toEqual('GEActionObjectError')
+    })
+    it('Should create GEActionObjectError with correct source', () => {
+      const error = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      expect(error.source).toEqual(GEErrorEnviornmentSource.ACTION_OBJECT)
+    })
+    it('Should throw GEActionObjectError', () => {
+      const error = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      try {
+        throw error
+        expect(false).toEqual(true)
+      } catch (err) {
+        expect(err).toEqual(error)
+      }
+    })
+    it('Should throw GEActionObjectError with stack', () => {
+      const error = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+      try {
+        throw error
+      } catch (err) {
+        expect(err.stack).not.toBeFalsy()
+      }
+    })
+    it('Should throw GEPAMError with message', () => {
+      try {
+        throw new GEActionObjectError(
+          'test message',
+          GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+        )
+      } catch (err) {
+        expect(err.message).toEqual('test message')
+      }
+    })
+  })
+
   describe('Serialization', () => {
     it('Serializes GEPAMError with properties', () => {
       const err = new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR)
@@ -109,6 +181,15 @@ describe('GEError', () => {
     })
     it('Serializes GECSMError with properties', () => {
       const err = new GECSMError('test message', GECSMErrorCodes.NO_FORWARDING_ADDRESS)
+      const serialized = err.toJSON()
+      const deserialized = GEError.fromJSON(serialized)
+      expect(deserialized).toEqual(err)
+    })
+    it('Serializes GEActionObjectError with properties', () => {
+      const err = new GEActionObjectError(
+        'test message',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
       const serialized = err.toJSON()
       const deserialized = GEError.fromJSON(serialized)
       expect(deserialized).toEqual(err)

--- a/src/GEError.ts
+++ b/src/GEError.ts
@@ -3,6 +3,7 @@ export enum GEErrorEnviornmentSource {
   PAM = 'PAM',
   FRONTEND = 'FRONTEND',
   RADIO = 'RADIO',
+  ACTION_OBJECT = 'ACTION_OBJECT',
   OTHER = 'OTHER'
 }
 
@@ -110,11 +111,34 @@ export class GECSMError extends GEError {
   }
 }
 
+/*****************************************
+ * ACTION_OBJECT
+ ****************************************/
+export enum GEActionObjectErrorCodes {
+  DESERIALIZATION_ERROR = 500
+}
+export class GEActionObjectError extends GEError {
+  // As far as i know there isnt a way to mock a constructor of the Error object
+  /* istanbul ignore next */
+  constructor(message: string, status: GEActionObjectErrorCodes) {
+    super(message, status, GEErrorEnviornmentSource.ACTION_OBJECT, 'GEActionObjectError')
+
+    /* istanbul ignore next */
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+
+  toJSON() {
+    return super.toJSON()
+  }
+}
+
 export default {
   GEError,
   GEErrorEnviornmentSource,
   GEPAMError,
   GEPAMErrorCodes,
   GECSMError,
-  GECSMErrorCodes
+  GECSMErrorCodes,
+  GEActionObjectError,
+  GEActionObjectErrorCodes
 }

--- a/src/GEError.ts
+++ b/src/GEError.ts
@@ -1,3 +1,5 @@
+import { requireProperty } from './utils'
+
 export enum GEErrorEnviornmentSource {
   CSM = 'CSM',
   PAM = 'PAM',
@@ -19,6 +21,7 @@ export class GEError extends Error {
   readonly name: string
   readonly source: GEErrorEnviornmentSource
   readonly stack?: string
+  readonly message: string
 
   constructor(
     message: string,
@@ -32,6 +35,7 @@ export class GEError extends Error {
     this.name = name
     this.status = status
     this.source = source
+    this.message = message
     if (stack) {
       this.stack = stack
     }
@@ -49,7 +53,35 @@ export class GEError extends Error {
   }
 
   static fromJSON(rawData: GEErrorJSON) {
-    return new GEError(rawData.message, rawData.status, rawData.source, rawData.name, rawData.stack)
+    if (!rawData.message) {
+      throw new GEActionObjectError(
+        'Error does not have valid "message" property',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+    } else if (!rawData.name) {
+      throw new GEActionObjectError(
+        'Error does not have valid "name" property',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+    } else if (!rawData.source) {
+      throw new GEActionObjectError(
+        'Error does not have valid "source" property',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+    } else if (!rawData.status) {
+      throw new GEActionObjectError(
+        'Error does not have valid "status" property',
+        GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+      )
+    } else {
+      return new GEError(
+        rawData.message,
+        rawData.status,
+        rawData.source,
+        rawData.name,
+        rawData.stack
+      )
+    }
   }
 }
 /*****************************************

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,5 @@
 import { requireProperty } from './utils'
+import { GEActionObjectError, GEActionObjectErrorCodes } from './GEError'
 
 describe('requireProperty', () => {
   it('Throws error if property doesnt exist', () => {
@@ -16,7 +17,12 @@ describe('requireProperty', () => {
       const testObj = ''
       requireProperty(testObj, 'asdf')
     } catch (error) {
-      expect(error).toEqual(new Error('Provided obj is not an object'))
+      expect(error).toEqual(
+        new GEActionObjectError(
+          'Cannot get property off of a non-object type',
+          GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+        )
+      )
     }
   })
   it('Returns property if it does exist', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,31 @@
+import { GEActionObjectError, GEActionObjectErrorCodes } from './GEError'
+import debug from 'debug'
+
+const actionObjectLog = debug('ge-fnm:action-object')
+
 export const requireProperty = (
   obj: any,
   prop: string,
   validator: (val: any) => boolean = () => true
 ) => {
+  actionObjectLog('Looking for property', prop, ' on obj', obj)
   if (typeof obj !== 'object') {
-    throw new Error('Provided obj is not an object')
+    actionObjectLog('Cannot get property off of a non-object type')
+    throw new GEActionObjectError(
+      'Cannot get property off of a non-object type',
+      GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+    )
   }
   if (!Object.keys(obj).includes(prop) || !validator(obj[prop])) {
-    throw new Error(`Object does not have valid "${prop}" property`)
+    actionObjectLog(
+      'Provided object does not have the property',
+      prop,
+      'or the property is not valid'
+    )
+    throw new GEActionObjectError(
+      `Object does not have valid "${prop}" property`,
+      GEActionObjectErrorCodes.DESERIALIZATION_ERROR
+    )
   } else {
     return obj[prop]
   }
@@ -25,9 +43,3 @@ export const ID = () => {
       .substr(2, 9)
   )
 }
-
-// export const removePropertyIf = (obj, property, validatorFunc) => {
-//   if(!validatorFunc(obi[property])){
-//     const
-//   }
-// }


### PR DESCRIPTION
- readme updates

- standardized the error types coming out of the action object deserialization 

- action object now requires a GEError type on the response.error field if the response.error field exists.

- it will automagically serialize and deserialize your errors for you when you call v1.deserialize and actionObject.serialize. 
Meaning, just put a GEError on the error field and everything else will be handled for you
```js 
  response: {
    error: new GEPAMError('test message', GEPAMErrorCodes.ADD_CLIENT_ERROR) // note that if error exists, it MUST be a serialized GEError
  },
```